### PR TITLE
Increase inflation table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ check-tests:
 	./vendor/bin/phpunit --testdox $(DIR_TEST)
 
 check-code-sniffer:
+	./vendor/bin/phpcbf \
+		--standard=PSR12 \
+		-p \
+		$(DIR_SOURCE)/ $(DIR_TEST)/; \
 	./vendor/bin/phpcs \
 		--standard=PSR12 \
 		-p \

--- a/www/Calculator.php
+++ b/www/Calculator.php
@@ -3,10 +3,23 @@
 namespace InflationCalculator;
 
 // https://www.czso.cz/csu/czso/mira_inflace
-
-const UNKNOWN_YEAR = 2.0;
+// https://vdb.czso.cz/vdbvo2/faces/cs/index.jsf?page=vystup-objekt&skupId=43&katalog=31779&z=T&f=TABULKA&pvo=CEN08C&pvo=CEN08C
+// https://eprehledy.cz/vyvoj_inflace_cr.php
+// http://www.czso.cz/csu/redakce.nsf/i/mira_inflace
 
 const YEAR_TABLE = array(
+    1993 => 20.8,
+    1994 => 10.0,
+    1995 => 9.1,
+    1996 => 8.8,
+    1997 => 8.5,
+    1998 => 10.7,
+    1999 => 2.1,
+    2000 => 3.9,
+    2001 => 4.7,
+    2002 => 1.8,
+    2003 => 0.1,
+    2004 => 2.8,
     2005 => 1.9,
     2006 => 2.5,
     2007 => 2.8,
@@ -29,6 +42,8 @@ const YEAR_TABLE = array(
 
 define('YEAR_MIN', min(array_keys(YEAR_TABLE)));
 define('YEAR_MAX', max(array_keys(YEAR_TABLE)) - 1);
+
+const UNKNOWN_YEAR = 2.0;
 
 class Calculator
 {

--- a/www/Calculator.php
+++ b/www/Calculator.php
@@ -73,6 +73,11 @@ class Calculator
 
         return $years;
     }
+
+    public function inflation(int $year): float
+    {
+        return YEAR_TABLE[$year];
+    }
 }
 
 /*

--- a/www/index.php
+++ b/www/index.php
@@ -133,6 +133,7 @@ if (isset($_GET['year']) && isset($_GET['month'])) {
                     <tr>
                     <th scope="col">Rok</th>
                     <th scope="col">Odpovídající hodnota&nbsp;Kč</th>
+                    <th scope="col">Inflace</th>
                     <th scope="col">Koeficient</th>
                     </tr>
                 </thead>
@@ -146,6 +147,7 @@ if (isset($_GET['year']) && isset($_GET['month'])) {
                     echo '>';
                     echo '<td>' . $y . '</td>';
                     echo '<td>' . round($table[$y]['value']) . '</td>';
+                    echo '<td>' . $calculator->inflation($y) . '%</td>';
                     echo '<td>' . sprintf("%0.3f", $table[$y]['coef']) . '</td>';
                     echo '</tr>';
                 }


### PR DESCRIPTION
It is little bit strange that CSO is providing values since 2005. I have found other sources that provide values from 1993.

# Testing :school: 

* `make check-all` - all tests are passing
* http://inflacni-kalkulacka.test/?year=1993&value=10000 - and it looks as expected
