### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,8 @@
 name: Deploy Website
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/martin-majlis/inflacni-kalkulacka.cz/security/code-scanning/1](https://github.com/martin-majlis/inflacni-kalkulacka.cz/security/code-scanning/1)

To fix this issue, we will add a `permissions` block at the workflow root level to restrict the `GITHUB_TOKEN` permissions to the least privilege required. Since the workflow uses `actions/checkout@v4` and deploys files to an FTP server, it likely only requires `contents: read`. We'll add this permission explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
